### PR TITLE
fix/regression: enclosed panic line in block for cfg directive

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -103,9 +103,10 @@ fn main() {
     } else if args.cmd_mnist {
         #[cfg(all(feature="cuda"))]
         run_mnist(args.arg_model_name, args.arg_batch_size, args.arg_learning_rate, args.arg_momentum);
-        #[cfg(not(feature="cuda"))]
-        println!("Right now, you really need cuda! Not all features are available for all backends and as such, this one -as of now - only works with cuda.");
-        panic!()
+        #[cfg(not(feature="cuda"))] {
+            println!("Right now, you really need cuda! Not all features are available for all backends and as such, this one -as of now - only works with cuda.");
+            panic!()
+        }
     }
 }
 


### PR DESCRIPTION
Closes #7. You'll need the updated juice repository that fixes #2 to test this.