### PR TITLE
feat/fashion-dropout: adds dropout to fashion example

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -12,7 +12,7 @@ dependencies = [
  "greenglas 0.2.0 (git+https://github.com/spearow/greenglas.git)",
  "hyper 0.11.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "hyper-tls 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "juice 0.2.2 (git+https://github.com/spearow/juice.git)",
+ "juice 0.2.2",
  "log 0.3.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "mnist 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "rustc-serialize 0.3.24 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -104,6 +104,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "bindgen"
+version = "0.30.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "aster 0.41.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "cexpr 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "cfg-if 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "clang-sys 0.19.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "clap 2.26.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "env_logger 0.4.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "lazy_static 0.2.9 (registry+https://github.com/rust-lang/crates.io-index)",
+ "log 0.3.8 (registry+https://github.com/rust-lang/crates.io-index)",
+ "peeking_take_while 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "quasi 0.32.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "quasi_codegen 0.32.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "regex 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "syntex_syntax 0.58.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "which 1.0.3 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "bitflags"
 version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -188,6 +209,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "clang-sys"
+version = "0.19.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "bitflags 0.9.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "glob 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.32 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libloading 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "clap"
 version = "2.26.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -238,13 +270,14 @@ dependencies = [
 [[package]]
 name = "coaster-nn"
 version = "0.4.1"
-source = "git+https://github.com/spearow/coaster-nn.git#f1bf1da7e9ab2b65b2f17b21e143e1bd42285ba7"
+source = "git+https://github.com/spearow/coaster-nn.git#736262d038bec0daa3a7212014330ff9dcabef0a"
 dependencies = [
  "coaster 0.1.0 (git+https://github.com/spearow/coaster.git)",
  "lazy_static 0.1.16 (registry+https://github.com/rust-lang/crates.io-index)",
  "libc 0.2.32 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.3.8 (registry+https://github.com/rust-lang/crates.io-index)",
- "rcudnn 1.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rand 0.3.17 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rcudnn 1.6.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -505,7 +538,6 @@ dependencies = [
 [[package]]
 name = "juice"
 version = "0.2.2"
-source = "git+https://github.com/spearow/juice.git#cb7d5ff62b32204706ca292b9facf866750da790"
 dependencies = [
  "capnp 0.8.11 (registry+https://github.com/rust-lang/crates.io-index)",
  "capnpc 0.8.7 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -905,20 +937,20 @@ dependencies = [
 
 [[package]]
 name = "rcudnn"
-version = "1.5.0"
+version = "1.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "libc 0.2.32 (registry+https://github.com/rust-lang/crates.io-index)",
  "num 0.1.40 (registry+https://github.com/rust-lang/crates.io-index)",
- "rcudnn-sys 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rcudnn-sys 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "rcudnn-sys"
-version = "0.1.0"
+version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "bindgen 0.25.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "bindgen 0.30.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "libc 0.2.32 (registry+https://github.com/rust-lang/crates.io-index)",
  "pkg-config 0.3.9 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -1340,6 +1372,14 @@ version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
+name = "which"
+version = "1.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "libc 0.2.32 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "winapi"
 version = "0.2.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1368,6 +1408,7 @@ dependencies = [
 "checksum atty 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)" = "21e50800ec991574876040fff8ee46b136a53e985286fbe6a3bdfe6421b78860"
 "checksum base64 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)" = "96434f987501f0ed4eb336a411e0631ecd1afa11574fe148587adc4ff96143c9"
 "checksum bindgen 0.25.5 (registry+https://github.com/rust-lang/crates.io-index)" = "cc7973dbc2990511877ad9e5e50a312f02fbbc9b356c30bb102307424fa73630"
+"checksum bindgen 0.30.0 (registry+https://github.com/rust-lang/crates.io-index)" = "33024f55a754d920637461adf87fb485702a69bdf7ac1d307b7e18da93bae505"
 "checksum bitflags 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)" = "32866f4d103c4e438b1db1158aa1b1a80ee078e5d77a59a2f906fd62a577389c"
 "checksum bitflags 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)" = "aad18937a628ec6abcd26d1489012cc0e18c21798210f491af69ded9b881106d"
 "checksum bitflags 0.8.2 (registry+https://github.com/rust-lang/crates.io-index)" = "1370e9fc2a6ae53aea8b7a5110edbd08836ed87c88736dfabccade1c2b44bff4"
@@ -1381,6 +1422,7 @@ dependencies = [
 "checksum cexpr 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "cdbb21df6ff3497a61df5059994297f746267020ba38ce237aad9c875f7b4313"
 "checksum cfg-if 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)" = "d4c819a1287eb618df47cc647173c5c4c66ba19d888a6e50d605672aed3140de"
 "checksum clang-sys 0.18.0 (registry+https://github.com/rust-lang/crates.io-index)" = "ff7c2d1502c65748c7221f43ce670b3ba5c697acebfeb85a580827daca6975fc"
+"checksum clang-sys 0.19.0 (registry+https://github.com/rust-lang/crates.io-index)" = "611ec2e3a7623afd8a8c0d027887b6b55759d894abbf5fe11b9dc11b50d5b49a"
 "checksum clap 2.26.2 (registry+https://github.com/rust-lang/crates.io-index)" = "3451e409013178663435d6f15fdb212f14ee4424a3d74f979d081d0a66b6f1f2"
 "checksum clippy 0.0.23 (registry+https://github.com/rust-lang/crates.io-index)" = "1ce8290038a10a7ff94a4eeb7868d32a32184ee0f47c0f602ea93f193c546a8b"
 "checksum coaster 0.1.0 (git+https://github.com/spearow/coaster.git)" = "<none>"
@@ -1415,7 +1457,6 @@ dependencies = [
 "checksum inflate 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "d1238524675af3938a7c74980899535854b88ba07907bb1c944abe5b8fc437e5"
 "checksum iovec 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "b6e8b9c2247fcf6c6a1151f1156932be5606c9fd6f55a2d7f9fc1cb29386b2f7"
 "checksum jpeg-decoder 0.1.13 (registry+https://github.com/rust-lang/crates.io-index)" = "2805ccb10ffe4d10e06ef68a158ff94c255211ecbae848fbde2146b098f93ce7"
-"checksum juice 0.2.2 (git+https://github.com/spearow/juice.git)" = "<none>"
 "checksum kernel32-sys 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "7507624b29483431c0ba2d82aece8ca6cdba9382bff4ddd0f7490560c056098d"
 "checksum language-tags 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "a91d884b6667cd606bb5a69aa0c99ba811a115fc68915e7056ec08a46e93199a"
 "checksum lazy_static 0.1.16 (registry+https://github.com/rust-lang/crates.io-index)" = "cf186d1a8aa5f5bee5fd662bc9c1b949e0259e1bcc379d1f006847b0080c7417"
@@ -1461,8 +1502,8 @@ dependencies = [
 "checksum rblas 0.0.13 (git+https://github.com/spearow/rust-blas)" = "<none>"
 "checksum rcublas 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "8719e68c483192885ad75ee824a2d21cf3231f8265190d75507fbd6d9de50314"
 "checksum rcublas-sys 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "84f658ed2e0ff654747928cfd05284debd9af3dadcd1d9e6d3369c60f45ac2aa"
-"checksum rcudnn 1.5.0 (registry+https://github.com/rust-lang/crates.io-index)" = "b555800b66b95d18a0518a6e05549403dbb4daf86e0c62a0a8e6ed3e27b97a02"
-"checksum rcudnn-sys 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "c16b4e4e1175a482b8717ec90a955c0dbde37aef3a38e040c2277624d782cb2d"
+"checksum rcudnn 1.6.0 (registry+https://github.com/rust-lang/crates.io-index)" = "661859511f6496ae830a70fa4df62c0e83f71fb191292efae9580f8efbe9fb12"
+"checksum rcudnn-sys 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "349abe733755957ff7919ba4928a83e50ad6f0103cc1aa9ee760c5507cce59d0"
 "checksum redox_syscall 0.1.31 (registry+https://github.com/rust-lang/crates.io-index)" = "8dde11f18c108289bef24469638a04dce49da56084f2d50618b226e47eb04509"
 "checksum redox_termios 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "7e891cfe48e9100a70a3b6eb652fef28920c117d366339687bd5576160db0f76"
 "checksum regex 0.1.80 (registry+https://github.com/rust-lang/crates.io-index)" = "4fd4ace6a8cf7860714a2c2280d6c1f7e6a413486c13298bbc86fd3da019402f"
@@ -1516,6 +1557,7 @@ dependencies = [
 "checksum vcpkg 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "9e0a7d8bed3178a8fb112199d466eeca9ed09a14ba8ad67718179b4fd5487d0b"
 "checksum vec_map 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)" = "887b5b631c2ad01628bbbaa7dd4c869f80d3186688f8d0b6f58774fbe324988c"
 "checksum void 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)" = "6a02e4885ed3bc0f2de90ea6dd45ebcbb66dacffe03547fadbb0eeae2770887d"
+"checksum which 1.0.3 (registry+https://github.com/rust-lang/crates.io-index)" = "4be6cfa54dab45266e98b5d7be2f8ce959ddd49abd141a05d52dce4b07f803bb"
 "checksum winapi 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)" = "167dc9d6949a9b857f3451275e911c3f44255842c1f7a76f33c55103a909087a"
 "checksum winapi-build 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "2d315eee3b34aca4797b2da6b13ed88266e6d612562a0c46390af8299fc699bc"
 "checksum ws2_32-sys 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "d59cefebd0c892fa2dd6de581e937301d8552cb44489cdff035c6187cb63fa5e"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,7 @@ authors = ["Bernhard Schuster <bernhard@ahoi.io>",
 
 [dependencies]
 greenglas = { git = "https://github.com/spearow/greenglas.git" }
-juice = { git = "https://github.com/spearow/juice.git", default-features = false }
+juice = { path = "../juice", default-features = false }
 coaster = { git = "https://github.com/spearow/coaster.git", default-features = false }
 
 csv = "0.15"

--- a/src/main.rs
+++ b/src/main.rs
@@ -436,6 +436,10 @@ fn run_fashion(
                 "linear1",
                 LinearConfig { output_size: 500 },
             ));
+            net_cfg.add_layer(LayerConfig::new(
+                "dropout",
+                DropoutConfig { probability: 0.8, seed: 42 },
+            ));
             net_cfg.add_layer(LayerConfig::new("sigmoid", LayerType::Sigmoid));
             net_cfg.add_layer(LayerConfig::new(
                 "linear2",


### PR DESCRIPTION
This shouldn't be merged as it is, because it changes the juice dependency to local again, but it helps test the dropout layer.